### PR TITLE
Typing

### DIFF
--- a/p2ptrans/core.py
+++ b/p2ptrans/core.py
@@ -264,7 +264,7 @@ def makeSphere(A, ncell, *atom_types, twoD=False):
 
         # Adds atoms to A and B (for cell with different types of atoms)
         Apos = []
-        atom_types = np.array([], np.str)
+        atom_types = np.array([], str)
         atomsA = np.array([], np.int)
         for a in A:
             if any(atom_types == a.type):

--- a/p2ptrans/core.py
+++ b/p2ptrans/core.py
@@ -265,7 +265,7 @@ def makeSphere(A, ncell, *atom_types, twoD=False):
         # Adds atoms to A and B (for cell with different types of atoms)
         Apos = []
         atom_types = np.array([], str)
-        atomsA = np.array([], np.int)
+        atomsA = np.array([], int)
         for a in A:
             if any(atom_types == a.type):
                 idx = np.where(atom_types == a.type)[0][0]
@@ -291,7 +291,7 @@ def makeSphere(A, ncell, *atom_types, twoD=False):
 
         atom_types = atom_types[0]
         Apos = [None]*len(atom_types)
-        atomsA = np.zeros(len(atom_types), np.int)
+        atomsA = np.zeros(len(atom_types), int)
         for a in A:
             idx = np.where(atom_types == a.type)[0][0]
             if atomsA[idx] == 0:

--- a/p2ptrans/utils.py
+++ b/p2ptrans/utils.py
@@ -53,7 +53,7 @@ def find_uvw(stretch_dir, basis = np.eye(3), size = 10, direction_only=True):
             cur_dist = la.norm(unit_vec-vec)
             if cur_dist < min_dist[l]:
                min_dist[l] = cur_dist
-               min_uvw[:,l] = np.array([i,j,k], np.int).T
+               min_uvw[:,l] = np.array([i,j,k], int).T
 
       if direction_only:
           gcd3 = gcd(min_uvw[0,l],gcd(min_uvw[1,l], min_uvw[2,l]))


### PR DESCRIPTION
Numpy has depreciated some types (like `np.int`) in favor of more specific types (PEP20:13). I'm pretty sure the text string type was what you meant at core:267, and switching the `np.int`s to `int`s replicates the current behavior. If we want to mandate that they are 64-bit ints, we could switch it to `np.int64` instead. 